### PR TITLE
Get rid of php notice at login

### DIFF
--- a/AdminRestrictBranch.module
+++ b/AdminRestrictBranch.module
@@ -269,7 +269,7 @@ class AdminRestrictBranch extends WireData implements Module, ConfigurableModule
 
         //if no match, default to the homepage: id = 1, but set noMatch variable
         //so it can be used in conjunction with the allOrNone setting to determine what they have access to
-        if($p->id) {
+        if($p && $p->id) {
             return $p->id;
         }
         else {


### PR DESCRIPTION
Cures a notice like "Notice: Trying to get property 'id' of non-object in /var/www/web/site/assets/cache/FileCompiler/site/modules/AdminRestrictBranch/AdminRestrictBranch.module on line 272" in ProcessWire Login Screen